### PR TITLE
Enable legacy-peer-deps to unblock npm install (ERESOLVE)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 save-exact=true
 package-lock=true
+legacy-peer-deps=true


### PR DESCRIPTION
`npm install` fails with `ERESOLVE`: `@cypress/eslint-plugin-dev@5` pulls a modern `@typescript-eslint` that peer-requires `eslint >=8`, while this project pins `eslint@7.0.0`.

Adding `legacy-peer-deps=true` to `.npmrc` restores pre-npm-7 resolution so install succeeds — in CI and for anyone cloning the repo. Pre-existing dependency issue (unrelated to the To-Do app migration), surfaced by the MagicLeap Tier 1 run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)